### PR TITLE
Fix file truncation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.1 (2020-11-03)
+
+Fixed bug where `jsonxf -i foo -o foo` would truncate `foo`.
+Thanks for the report, [@anthhub](https://github.com/anthhub)!
+
 ## 1.0.0 (2020-06-29)
 
 Updated to latest `getopts` and fixed some deprecated style.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonxf"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["pete gamache <pete@gamache.org>"]
 description = "A fast JSON pretty-printer and minimizer."
 homepage = "https://github.com/gamache/jsonxf"

--- a/src/jsonxf.rs
+++ b/src/jsonxf.rs
@@ -71,11 +71,11 @@ pub struct Formatter {
     pub trailing_output: String,
 
     // private mutable state
-    depth: usize, // current nesting depth
-    in_string: bool, // is the next byte part of a string?
+    depth: usize,       // current nesting depth
+    in_string: bool,    // is the next byte part of a string?
     in_backslash: bool, // does the next byte follow a backslash in a string?
-    empty: bool, // is the next byte in an empty object or array?
-    first: bool, // is this the first byte of input?
+    empty: bool,        // is the next byte in an empty object or array?
+    first: bool,        // is this the first byte of input?
 }
 
 impl Formatter {
@@ -179,7 +179,11 @@ impl Formatter {
     ///     Err(e) => { panic!(e.to_string()); }
     /// }
     /// ```
-    pub fn format_stream(&mut self, input: &mut dyn Read, output: &mut dyn Write) -> Result<(), Error> {
+    pub fn format_stream(
+        &mut self,
+        input: &mut dyn Read,
+        output: &mut dyn Write,
+    ) -> Result<(), Error> {
         let mut reader = BufReader::new(input);
         let mut writer = BufWriter::new(output);
         let mut buf = [0 as u8; BUF_SIZE];
@@ -199,7 +203,6 @@ impl Formatter {
         writer.write(self.trailing_output.as_bytes())?;
         return Ok(());
     }
-
 
     /* Formats the contents of `buf` into `writer`. */
     fn format_buf(&mut self, buf: &[u8], writer: &mut dyn Write) -> Result<(), Error> {
@@ -231,7 +234,6 @@ impl Formatter {
                                 writer.write(self.indent.as_bytes())?;
                             }
                             writer.write(&buf[n..n + 1])?;
-
                         } else if self.depth == 0 {
                             writer.write(self.record_separator.as_bytes())?;
                             writer.write(&buf[n..n + 1])?;

--- a/tests/formatter_test.rs
+++ b/tests/formatter_test.rs
@@ -27,7 +27,8 @@ fn record_separator() {
     xf.record_separator = String::from("X");
     assert_eq!(
         "{\"a\":{\"b\":{\"c\":3}}}X{\"a\":{\"b\":{\"c\":3}}}",
-        xf.format("{\"a\":{\"b\":{\"c\":3}}}{\"a\":{\"b\":{\"c\":3}}}").unwrap()
+        xf.format("{\"a\":{\"b\":{\"c\":3}}}{\"a\":{\"b\":{\"c\":3}}}")
+            .unwrap()
     );
 }
 
@@ -50,4 +51,3 @@ fn trailing_output() {
         xf.format("{\"a\":{\"b\":{\"c\":3}}}").unwrap()
     );
 }
-

--- a/tests/minimize_test.rs
+++ b/tests/minimize_test.rs
@@ -2,37 +2,37 @@ extern crate jsonxf;
 
 #[test]
 fn minimize_passes_test_cases() {
-  let test_cases: Vec<[&str; 2]> = vec![
-    [ // one object, one k-v pair
-      " { \"hello\": \"world\" } \r\n",
-      "{\"hello\":\"world\"}",
-    ],
+    let test_cases: Vec<[&str; 2]> = vec![
+        [
+            // one object, one k-v pair
+            " { \"hello\": \"world\" } \r\n",
+            "{\"hello\":\"world\"}",
+        ],
+        [
+            // one object, several k-v pairs
+            " { \"hello\": \"world\",\r\n  \"wow\": \"cool\"  } \r\n",
+            "{\"hello\":\"world\",\"wow\":\"cool\"}",
+        ],
+        [
+            // one object per line
+            " { \"hello\": \"world\"}\r\n  { \"wow\": \"cool\"  } \r\n",
+            "{\"hello\":\"world\"}\n{\"wow\":\"cool\"}",
+        ],
+        [
+            // empty object
+            " { \"hello\": {} } \r\n",
+            "{\"hello\":{}}",
+        ],
+        [
+            // nested structures
+            " { \"hello\": [ \"world\" , 22 ] } \r\n",
+            "{\"hello\":[\"world\",22]}",
+        ],
+    ];
 
-    [ // one object, several k-v pairs
-      " { \"hello\": \"world\",\r\n  \"wow\": \"cool\"  } \r\n",
-      "{\"hello\":\"world\",\"wow\":\"cool\"}",
-    ],
-
-    [ // one object per line
-      " { \"hello\": \"world\"}\r\n  { \"wow\": \"cool\"  } \r\n",
-      "{\"hello\":\"world\"}\n{\"wow\":\"cool\"}",
-    ],
-
-    [ // empty object
-      " { \"hello\": {} } \r\n",
-      "{\"hello\":{}}",
-    ],
-
-    [ // nested structures
-      " { \"hello\": [ \"world\" , 22 ] } \r\n",
-      "{\"hello\":[\"world\",22]}",
-    ],
-  ];
-
-  for case in test_cases {
-    let input = case[0];
-    let output = case[1];
-    assert_eq!(jsonxf::minimize(input).unwrap(), output);
-  }
+    for case in test_cases {
+        let input = case[0];
+        let output = case[1];
+        assert_eq!(jsonxf::minimize(input).unwrap(), output);
+    }
 }
-

--- a/tests/pretty_print_test.rs
+++ b/tests/pretty_print_test.rs
@@ -2,57 +2,57 @@ extern crate jsonxf;
 
 #[test]
 fn pretty_print_passes_test_cases() {
-  let test_cases: Vec<[&str; 2]> = vec![
-    [ // one object, one k-v pair
-      "{\"hello\":\"world\"}",
-      "{\n  \"hello\": \"world\"\n}",
-    ],
+    let test_cases: Vec<[&str; 2]> = vec![
+        [
+            // one object, one k-v pair
+            "{\"hello\":\"world\"}",
+            "{\n  \"hello\": \"world\"\n}",
+        ],
+        [
+            // one object, several k-v pairs
+            " { \"hello\": \"world2\",\r\n  \"wow\": \"cool\"  } \r\n",
+            "{\n  \"hello\": \"world2\",\n  \"wow\": \"cool\"\n}",
+        ],
+        [
+            // simple array
+            "[1,2,3]",
+            "[\n  1,\n  2,\n  3\n]",
+        ],
+        [
+            // one object per line, with blank lines and missing newlines
+            " { \"hello\": \"world3\"}\r\n\n\n  { \"wow\": \"cool\"  }{\"a\":\"b\"}",
+            "{\n  \"hello\": \"world3\"\n}\n{\n  \"wow\": \"cool\"\n}\n{\n  \"a\": \"b\"\n}",
+        ],
+        [
+            // one array per line, with blank lines and missing newlines
+            "[1, 2, \"omg\"]\n\n\n[\"whee\", {}, 22][]",
+            "[\n  1,\n  2,\n  \"omg\"\n]\n[\n  \"whee\",\n  {},\n  22\n]\n[]",
+        ],
+        [
+            // nested empty array
+            " { \"hello\": [\n\n] }",
+            "{\n  \"hello\": []\n}",
+        ],
+        [
+            // nested empty object
+            " { \"hello\": {} }",
+            "{\n  \"hello\": {}\n}",
+        ],
+        [
+            // nested structures
+            " { \"hello\": [ \"world5\" , 22 ] } \r\n",
+            "{\n  \"hello\": [\n    \"world5\",\n    22\n  ]\n}",
+        ],
+        [
+            // empty object special case
+            " { \n\r\n\t } ",
+            "{}",
+        ],
+    ];
 
-    [ // one object, several k-v pairs
-      " { \"hello\": \"world2\",\r\n  \"wow\": \"cool\"  } \r\n",
-      "{\n  \"hello\": \"world2\",\n  \"wow\": \"cool\"\n}",
-    ],
-
-    [ // simple array
-      "[1,2,3]",
-      "[\n  1,\n  2,\n  3\n]",
-    ],
-
-    [ // one object per line, with blank lines and missing newlines
-      " { \"hello\": \"world3\"}\r\n\n\n  { \"wow\": \"cool\"  }{\"a\":\"b\"}",
-      "{\n  \"hello\": \"world3\"\n}\n{\n  \"wow\": \"cool\"\n}\n{\n  \"a\": \"b\"\n}",
-    ],
-
-    [ // one array per line, with blank lines and missing newlines
-      "[1, 2, \"omg\"]\n\n\n[\"whee\", {}, 22][]",
-      "[\n  1,\n  2,\n  \"omg\"\n]\n[\n  \"whee\",\n  {},\n  22\n]\n[]",
-    ],
-
-    [ // nested empty array
-      " { \"hello\": [\n\n] }",
-      "{\n  \"hello\": []\n}",
-    ],
-
-    [ // nested empty object
-      " { \"hello\": {} }",
-      "{\n  \"hello\": {}\n}",
-    ],
-
-    [ // nested structures
-      " { \"hello\": [ \"world5\" , 22 ] } \r\n",
-      "{\n  \"hello\": [\n    \"world5\",\n    22\n  ]\n}",
-    ],
-
-    [ // empty object special case
-      " { \n\r\n\t } ",
-      "{}",
-    ],
-  ];
-
-  for case in test_cases {
-    let input = case[0];
-    let output = case[1];
-    assert_eq!(jsonxf::pretty_print(input).unwrap(), output);
-  }
+    for case in test_cases {
+        let input = case[0];
+        let output = case[1];
+        assert_eq!(jsonxf::pretty_print(input).unwrap(), output);
+    }
 }
-

--- a/tests/test_cases_test.rs
+++ b/tests/test_cases_test.rs
@@ -4,13 +4,22 @@ use std::io::Read;
 
 fn test(name: &str) {
     let mut input = String::new();
-    File::open(format!("./tests/test_cases/{}.json", name)).unwrap().read_to_string(&mut input).unwrap();
+    File::open(format!("./tests/test_cases/{}.json", name))
+        .unwrap()
+        .read_to_string(&mut input)
+        .unwrap();
 
     let mut pretty = String::new();
-    File::open(format!("./tests/test_cases/{}.pretty.json", name)).unwrap().read_to_string(&mut pretty).unwrap();
+    File::open(format!("./tests/test_cases/{}.pretty.json", name))
+        .unwrap()
+        .read_to_string(&mut pretty)
+        .unwrap();
 
     let mut min = String::new();
-    File::open(format!("./tests/test_cases/{}.min.json", name)).unwrap().read_to_string(&mut min).unwrap();
+    File::open(format!("./tests/test_cases/{}.min.json", name))
+        .unwrap()
+        .read_to_string(&mut min)
+        .unwrap();
 
     assert_eq!(pretty, jsonxf::pretty_print(&input).unwrap());
     assert_eq!(min, jsonxf::minimize(&input).unwrap());


### PR DESCRIPTION
This PR adds proper handling of `jsonxf -i foo -o foo`, writing to a `foo.tmp` temp file and renaming it to `foo` when finished.

Fixes #5. 