### PR TITLE
Various tweaks and additions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,14 @@ name = "jsonxf"
 version = "1.0.2"
 dependencies = [
  "getopts",
+ "memchr",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 
 [dependencies]
 getopts = "0.2"
+memchr = "2.3.4"
 
 [lib]
 name = "jsonxf"

--- a/src/jsonxf.rs
+++ b/src/jsonxf.rs
@@ -236,8 +236,17 @@ impl Formatter {
         return Ok(());
     }
 
-    /* Formats the contents of `buf` into `writer`. */
-    fn format_buf(&mut self, buf: &[u8], writer: &mut impl Write) -> Result<(), Error> {
+    /// Format directly from a buffer into a writer.
+    ///
+    /// # Example:
+    ///
+    /// ```no_run
+    /// let text = "[1, 2, 3]";
+    /// let mut fmt = jsonxf::Formatter::pretty_printer();
+    /// let mut stdout = std::io::stdout();
+    /// fmt.format_buf(text.as_bytes(), &mut stdout).unwrap();
+    /// ```
+    pub fn format_buf(&mut self, buf: &[u8], writer: &mut impl Write) -> Result<(), Error> {
         let mut n = 0;
         while n < buf.len() {
             let b = buf[n];

--- a/src/jsonxf.rs
+++ b/src/jsonxf.rs
@@ -70,6 +70,10 @@ pub struct Formatter {
     /// Used at very end of output.
     pub trailing_output: String,
 
+    /// Add a record_separator as soon as a record ends, before seeing a
+    /// subsequent record. Useful when there's a long time between records.
+    pub eager_record_separators: bool,
+
     // private mutable state
     depth: usize,       // current nesting depth
     in_string: bool,    // is the next byte part of a string?
@@ -86,6 +90,7 @@ impl Formatter {
             record_separator: String::from("\n"),
             after_colon: String::from(" "),
             trailing_output: String::from(""),
+            eager_record_separators: false,
             depth: 0,
             in_string: false,
             in_backslash: false,
@@ -275,7 +280,7 @@ impl Formatter {
                                 writer.write_all(self.indent.as_bytes())?;
                             }
                             writer.write_all(&buf[n..n + 1])?;
-                        } else if self.depth == 0 {
+                        } else if !self.eager_record_separators && self.depth == 0 {
                             writer.write_all(self.record_separator.as_bytes())?;
                             writer.write_all(&buf[n..n + 1])?;
                         } else {
@@ -296,6 +301,9 @@ impl Formatter {
                                 writer.write_all(self.indent.as_bytes())?;
                             }
                             writer.write_all(&buf[n..n + 1])?;
+                        }
+                        if self.eager_record_separators && self.depth == 0 {
+                            writer.write_all(self.record_separator.as_bytes())?;
                         }
                     }
 

--- a/src/jsonxf.rs
+++ b/src/jsonxf.rs
@@ -200,7 +200,7 @@ impl Formatter {
                 }
             }
         }
-        writer.write(self.trailing_output.as_bytes())?;
+        writer.write_all(self.trailing_output.as_bytes())?;
         return Ok(());
     }
 
@@ -210,7 +210,7 @@ impl Formatter {
             let b = buf[n];
 
             if self.in_string {
-                writer.write(&buf[n..n + 1])?;
+                writer.write_all(&buf[n..n + 1])?;
                 if self.in_backslash {
                     self.in_backslash = false;
                 } else if b == C_QUOTE {
@@ -227,18 +227,18 @@ impl Formatter {
                     C_LEFT_BRACKET | C_LEFT_BRACE => {
                         if self.first {
                             self.first = false;
-                            writer.write(&buf[n..n + 1])?;
+                            writer.write_all(&buf[n..n + 1])?;
                         } else if self.empty {
-                            writer.write(self.line_separator.as_bytes())?;
+                            writer.write_all(self.line_separator.as_bytes())?;
                             for _ in 0..self.depth {
-                                writer.write(self.indent.as_bytes())?;
+                                writer.write_all(self.indent.as_bytes())?;
                             }
-                            writer.write(&buf[n..n + 1])?;
+                            writer.write_all(&buf[n..n + 1])?;
                         } else if self.depth == 0 {
-                            writer.write(self.record_separator.as_bytes())?;
-                            writer.write(&buf[n..n + 1])?;
+                            writer.write_all(self.record_separator.as_bytes())?;
+                            writer.write_all(&buf[n..n + 1])?;
                         } else {
-                            writer.write(&buf[n..n + 1])?;
+                            writer.write_all(&buf[n..n + 1])?;
                         }
                         self.depth += 1;
                         self.empty = true;
@@ -248,41 +248,41 @@ impl Formatter {
                         self.depth = self.depth.saturating_sub(1);
                         if self.empty {
                             self.empty = false;
-                            writer.write(&buf[n..n + 1])?;
+                            writer.write_all(&buf[n..n + 1])?;
                         } else {
-                            writer.write(self.line_separator.as_bytes())?;
+                            writer.write_all(self.line_separator.as_bytes())?;
                             for _ in 0..self.depth {
-                                writer.write(self.indent.as_bytes())?;
+                                writer.write_all(self.indent.as_bytes())?;
                             }
-                            writer.write(&buf[n..n + 1])?;
+                            writer.write_all(&buf[n..n + 1])?;
                         }
                     }
 
                     C_COMMA => {
-                        writer.write(&buf[n..n + 1])?;
-                        writer.write(self.line_separator.as_bytes())?;
+                        writer.write_all(&buf[n..n + 1])?;
+                        writer.write_all(self.line_separator.as_bytes())?;
                         for _ in 0..self.depth {
-                            writer.write(self.indent.as_bytes())?;
+                            writer.write_all(self.indent.as_bytes())?;
                         }
                     }
 
                     C_COLON => {
-                        writer.write(&buf[n..n + 1])?;
-                        writer.write(self.after_colon.as_bytes())?;
+                        writer.write_all(&buf[n..n + 1])?;
+                        writer.write_all(self.after_colon.as_bytes())?;
                     }
 
                     _ => {
                         if self.empty {
-                            writer.write(self.line_separator.as_bytes())?;
+                            writer.write_all(self.line_separator.as_bytes())?;
                             for _ in 0..self.depth {
-                                writer.write(self.indent.as_bytes())?;
+                                writer.write_all(self.indent.as_bytes())?;
                             }
                             self.empty = false;
                         }
                         if b == C_QUOTE {
                             self.in_string = true;
                         }
-                        writer.write(&buf[n..n + 1])?;
+                        writer.write_all(&buf[n..n + 1])?;
                     }
                 };
             };

--- a/src/jsonxf.rs
+++ b/src/jsonxf.rs
@@ -22,6 +22,7 @@ use std::io::prelude::*;
 use std::io::BufReader;
 use std::io::BufWriter;
 use std::io::Error;
+use std::io::ErrorKind;
 
 const BUF_SIZE: usize = 1024 * 16;
 
@@ -222,6 +223,9 @@ impl Formatter {
                 }
                 Ok(n) => {
                     self.format_buf(&buf[0..n], output)?;
+                }
+                Err(e) if e.kind() == ErrorKind::Interrupted => {
+                    continue;
                 }
                 Err(e) => {
                     return Err(e);

--- a/src/jsonxf.rs
+++ b/src/jsonxf.rs
@@ -238,6 +238,10 @@ impl Formatter {
 
     /// Format directly from a buffer into a writer.
     ///
+    /// This may be called on chunks of a JSON document to format it bit by bit.
+    ///
+    /// As such, it does not add the `trailing_output` at the end.
+    ///
     /// # Example:
     ///
     /// ```no_run

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@
   Run `jsonxf -h` for usage options.
 */
 
-use std::fs::File;
+use std::{fs::File, io::ErrorKind};
 
 extern crate jsonxf;
 
@@ -159,6 +159,7 @@ fn do_main() -> Result<(), String> {
     }
 
     match result {
+        Err(e) if e.kind() == ErrorKind::BrokenPipe => Ok(()),
         Err(e) => Err(e.to_string()),
         Ok(_) => Ok(()),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,8 @@ fn do_main() -> Result<(), String> {
     } else {
         let mut xf = jsonxf::Formatter::pretty_printer();
         xf.indent = indent;
+        // Ensure a trailing newline, as expected on Unix
+        xf.eager_record_separators = true;
         xf.format_stream(&mut input, &mut output)
     };
 

--- a/tests/pretty_print_test.rs
+++ b/tests/pretty_print_test.rs
@@ -56,3 +56,17 @@ fn pretty_print_passes_test_cases() {
         assert_eq!(jsonxf::pretty_print(input).unwrap(), output);
     }
 }
+
+#[test]
+fn eager_record_separators() {
+    let test_cases = vec![
+        ("{1: 1}{}", "{\n  1: 1\n}\n{}\n"),
+        ("{1: 1}{1: 1}", "{\n  1: 1\n}\n{\n  1: 1\n}\n"),
+        ("[]", "[]\n"),
+    ];
+    for (input, output) in test_cases {
+        let mut printer = jsonxf::Formatter::pretty_printer();
+        printer.eager_record_separators = true;
+        assert_eq!(printer.format(input).unwrap(), output);
+    }
+}


### PR DESCRIPTION
I've put these in one PR for convenience, but they're separate commits so you can pick and choose.

For context, we use `jsonxf` to pretty-print HTTP responses in [`xh`](https://github.com/ducaale/xh). It's a great fit!

For the benefit of `xh`:
- Add `format_stream_unbuffered` alternative API: `xh` has a streaming mode, where data is printed as it comes in, line by line. That doesn't work well with `BufWriter`, because it can take a while for the buffer to fill up. I'd like to use [`LineWriter`](https://doc.rust-lang.org/std/io/struct.LineWriter.html) instead, which flushes its buffer when it sees a newline. So I added an alternative to `format_stream` that doesn't add buffering, so you can bring your own.
- Make `format_buf` public: Sometimes you want to format directly from a string, and then that method is the most suitable.
- Add option to add record separator as soon as a record ends: `LineWriter` flushes when it sees a newline, but `jsonxf` prints one at the start of a record, not at the end, so the last line of a record was being flushed too late. This configuration switches that around. That also means it adds a newline after the last record, so it can't be the default without breakage.

Correctness and performance:
- Replace `write()` by `write_all()`: `write()` doesn't ensure all data is written, you might have to call it multiple times. `write_all()` takes care of that. That does unfortunately slow it down slightly.
- Speed up string processing with [`memchr`](https://docs.rs/memchr): I used this to efficiently search for backslashes and quotes in strings, to make up for the `write_all()` performance loss. On a basic benchmark it looked about 25% faster, on a silly benchmark with 1000-character strings it was eight times as fast. This makes the code slightly more complicated, but hopefully not too much.
- Ignore `ErrorKind::Interrupted`: That error is supposed to be [non-fatal](https://doc.rust-lang.org/std/io/trait.Read.html#errors), though I don't think it comes up much.

Command line tool:
- Ignore broken pipes to avoid spurious error messages: If you run e.g. `jsonxf | head` then it crashes with error message `Broken pipe (os error 32)`. I made it exit quietly on that particular error, which is normal for these sorts of tools.
- Make the command line tool add a trailing newline: Text files on Unix normally end with a newline, but `jsonxf` didn't add one. Adding one seemed appropriate for pretty-printing. (This is arguably a breaking change, not sure if that's ok.)

(Sorry for the long list of changes—we've vendored `jsonxf` for now, so if you'd prefer to close this that's fine)